### PR TITLE
Ensure set_gas_heater_temperature calls _set_regs with int

### DIFF
--- a/library/bme680/__init__.py
+++ b/library/bme680/__init__.py
@@ -182,7 +182,7 @@ class BME680(BME680Data):
             raise ValueError("Profile '{}' should be between {} and {}".format(nb_profile, NBCONV_MIN, NBCONV_MAX))
 
         self.gas_settings.heatr_temp = value
-        temp = self._calc_heater_resistance(self.gas_settings.heatr_temp)
+        temp = int(self._calc_heater_resistance(self.gas_settings.heatr_temp))
         self._set_regs(RES_HEAT0_ADDR + nb_profile, temp)
 
     def set_gas_heater_duration(self, value, nb_profile=0):


### PR DESCRIPTION
When running the `examples/read-all.py` script I was seeing a crash because
the value passed to `write_i2c_block_data` wasn't being converted to an int:

```
  File "/home/pi/tmp/bme680/library/bme680/__init__.py", line 281, in _set_regs
    self._i2c.write_i2c_block_data(self.i2c_addr, register, value)
TypeError: Third argument must be a list of at least one, but not more than 32 integers
```

This commit ensures `set_gas_heater_temperature` converts the temperature to an int
before it's passed to `self._set_regs`.