### PR TITLE
Fix reassignment of variable in pressure calculation algo

### DIFF
--- a/library/bme680/__init__.py
+++ b/library/bme680/__init__.py
@@ -304,9 +304,9 @@ class BME680(BME680Data):
             self.calibration_data.par_p6) >> 2
         var2 = var2 + ((var1 * self.calibration_data.par_p5) << 1)
         var2 = (var2 >> 2) + (self.calibration_data.par_p4 << 16)
-
-        var1 = ((var1 >> 2) * (var1 >> 2)) >> 13
-        var1 = ((var1 * (self.calibration_data.par_p3 << 5)) >> 3) + ((self.calibration_data.par_p2 * var1) >> 1)
+        var1 = (((((var1 >> 2) * (var1 >> 2)) >> 13 ) *
+                ((self.calibration_data.par_p3 << 5)) >> 3) +
+                ((self.calibration_data.par_p2 * var1) >> 1))
         var1 = var1 >> 18
 
         var1 = ((32768 + var1) * self.calibration_data.par_p1) >> 15


### PR DESCRIPTION
Found it! I'm not 100% sure what's going on here, but I think the problem is that you reassigned var1 but the last part of the calculation relied on its original value.

With this patch I get matching values from the C and the Python.